### PR TITLE
Fix JSON syntax errors in rules.json

### DIFF
--- a/assets/data/rules.json
+++ b/assets/data/rules.json
@@ -60,9 +60,9 @@
     "ABILENE": { "type": "BLOCK", "msg": "AUTO REJECT: Abilene, TX" },
     "GARLAND": { "type": "BLOCK", "msg": "AUTO REJECT: Garland, TX" },
     "MIDLAND": { "type": "BLOCK", "msg": "AUTO REJECT: Midland, TX" },
-    "WICHITA FALLS": { "type": "BLOCK", "msg": "AUTO REJECT: Wichita Falls, TX" }
+    "WICHITA FALLS": { "type": "BLOCK", "msg": "AUTO REJECT: Wichita Falls, TX" },
     "SPOKANE": { "type": "BLOCK", "msg": "AUTO REJECT: Spokane, WA" },
     "STILLWATER": { "type": "BLOCK", "msg": "AUTO REJECT: Stillwater, MN" },
     "ST. PAUL": { "type": "BLOCK", "msg": "AUTO REJECT: St. Paul, MN" },
-    "APPLE VALLEY": { "type": "BLOCK", "msg": "AUTO REJECT: Apple Valley, MN" },    
+    "APPLE VALLEY": { "type": "BLOCK", "msg": "AUTO REJECT: Apple Valley, MN" }
 }


### PR DESCRIPTION
Fixed JSON syntax errors in `assets/data/rules.json`. Added a missing comma after "WICHITA FALLS" and removed a trailing comma after "APPLE VALLEY". This resolves the issue where recent updates to the rules were not being applied to users due to JSON parsing failures.

---
*PR created automatically by Jules for task [15600676631396196491](https://jules.google.com/task/15600676631396196491) started by @MSMelok*